### PR TITLE
Поддержка Linux и Mac OS X

### DIFF
--- a/main.js
+++ b/main.js
@@ -311,7 +311,7 @@ try {
             flashPath = app.getPath('pepperFlashSystemPlugin');
             break
         case 'darwin':
-            flashPath = "/Library/Internet"+" "+"Plug-Ins/PepperFlashPlayer/PepperFlashPlayer.plugin/Contents/MacOS/PepperFlashPlayer";
+            flashPath = "/Library/Internet\ Plug-Ins/PepperFlashPlayer/PepperFlashPlayer.plugin/Contents/MacOS/PepperFlashPlayer";
             break
         case 'linux':
             app.commandLine.appendSwitch('--no-sandbox'); //work around, Electron bug https://github.com/electron/electron/issues/20309

--- a/main.js
+++ b/main.js
@@ -292,8 +292,32 @@ if (!gotTheLock) {
     });
 }
 
+function getLinuxFlashPath() {
+    let flashPath = '';
+    if (fs.existsSync('/usr/lib/pepperflashplugin-nonfree/')) {
+        flashPath = '/usr/lib/pepperflashplugin-nonfree/libpepflashplayer.so';
+    } else if (fs.existsSync('/usr/lib/pepflashplugin-installer/')) {
+        flashPath = '/usr/lib/pepflashplugin-installer/libpepflashplayer.so';
+    } else if (fs.existsSync('/usr/lib/pepper-plugins/')) {
+        flashPath = '/usr/lib/pepper-plugins/libpepflashplayer.so';
+    }
+    return flashPath;
+}
+
 try {
-    const flashPath = app.getPath('pepperFlashSystemPlugin');
+    let flashPath = '';
+    switch (process.platform) {
+        case 'win32':
+            flashPath = app.getPath('pepperFlashSystemPlugin');
+            break
+        case 'darwin':
+            flashPath = "/Library/Internet"+" "+"Plug-Ins/PepperFlashPlayer/PepperFlashPlayer.plugin/Contents/MacOS/PepperFlashPlayer";
+            break
+        case 'linux':
+            app.commandLine.appendSwitch('--no-sandbox'); //work around, Electron bug https://github.com/electron/electron/issues/20309
+            flashPath = getLinuxFlashPath();
+            break
+    }
     app.commandLine.appendSwitch('ppapi-flash-path', flashPath);
 } catch (e) {
     shell.openExternal('https://get.adobe.com/ru/flashplayer/otherversions/');

--- a/package.json
+++ b/package.json
@@ -12,11 +12,15 @@
   "build": {
     "appId": "pw.timezero",
     "productName": "TimeZeroPW",
-    "extraFiles": "game/**/*"
+    "extraFiles": "game/**/*",
+    "linux": {
+      "category": "game",
+      "target": ["Appimage","tar.gz"]
+    }
   },
   "devDependencies": {
     "electron": "latest",
-    "electron-builder": "latest"
+    "electron-builder": "^22.8.0"
   },
   "dependencies": {
     "electron-store": "latest",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,15 @@
     "extraFiles": "game/**/*",
     "linux": {
       "category": "game",
-      "target": ["Appimage","tar.gz"]
+      "target": [
+        "Appimage",
+        "tar.gz"
+      ]
     }
   },
   "devDependencies": {
     "electron": "latest",
-    "electron-builder": "^22.8.0"
+    "electron-builder": "latest"
   },
   "dependencies": {
     "electron-store": "latest",


### PR DESCRIPTION
Добавлены возможные пути до Pepperflash на Linux и Mac OS X. Оставляет сборку для Linux только Appimage и tar.gz. Snap без регистрации всё равно не работает. Добавляет категорию приложения, чтобы сборщик не ругался.